### PR TITLE
Fixed deprecation notices

### DIFF
--- a/src/Description/Document/Parser/YamlParser.php
+++ b/src/Description/Document/Parser/YamlParser.php
@@ -38,11 +38,13 @@ class YamlParser implements Parser
     public function parse(string $string)
     {
         try {
-            if (defined('Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE')) { 
-                return $this->parser->parse($string, Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE);
+            if (defined('\Symfony\Component\Yaml\Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE')) {
+                return $this->parser->parse(
+                    $string,
+                    Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE | Yaml::PARSE_OBJECT_FOR_MAP
+                );
             } else {
-                $data = $this->parser->parse($string, true, false, false);
-                return $this->fixHashMaps($data);
+                return $this->fixHashMaps($this->parser->parse($string, true, false, false));                
             }        
         } catch (\Throwable $e) {
             throw new ParseException("Failed to parse as YAML", 0, $e);

--- a/src/Description/Document/Parser/YamlParser.php
+++ b/src/Description/Document/Parser/YamlParser.php
@@ -9,6 +9,7 @@
 namespace KleijnWeb\PhpApi\Descriptions\Description\Document\Parser;
 
 use Symfony\Component\Yaml\Parser as SymfonyYamlParser;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * @author John Kleijn <john@kleijnweb.nl>
@@ -38,7 +39,7 @@ class YamlParser implements Parser
     {
         try {
             // Hashmap support is broken in a lot of versions, so disable it and attempt fix afterwards
-            $data = $this->parser->parse($string, true, false, false);
+            $data = $this->parser->parse($string, Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE);
         } catch (\Throwable $e) {
             throw new ParseException("Failed to parse as YAML", 0, $e);
         }

--- a/src/Description/Document/Parser/YamlParser.php
+++ b/src/Description/Document/Parser/YamlParser.php
@@ -38,13 +38,15 @@ class YamlParser implements Parser
     public function parse(string $string)
     {
         try {
-            // Hashmap support is broken in a lot of versions, so disable it and attempt fix afterwards
-            $data = $this->parser->parse($string, Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE);
+            if (defined('Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE')) { 
+                return $this->parser->parse($string, Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE);
+            } else {
+                $data = $this->parser->parse($string, true, false, false);
+                return $this->fixHashMaps($data);
+            }        
         } catch (\Throwable $e) {
             throw new ParseException("Failed to parse as YAML", 0, $e);
         }
-
-        return $this->fixHashMaps($data);
     }
 
     /**

--- a/src/Description/Document/Parser/YamlParser.php
+++ b/src/Description/Document/Parser/YamlParser.php
@@ -44,7 +44,8 @@ class YamlParser implements Parser
                     Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE | Yaml::PARSE_OBJECT_FOR_MAP
                 );
             } else {
-                return $this->fixHashMaps($this->parser->parse($string, true, false, false));                
+                $data = $this->parser->parse($string, true, false, false);
+                return $this->fixHashMaps($data);                
             }        
         } catch (\Throwable $e) {
             throw new ParseException("Failed to parse as YAML", 0, $e);
@@ -58,7 +59,7 @@ class YamlParser implements Parser
      *
      * @return mixed
      */
-    private function fixHashMaps($data)
+    private function fixHashMaps(&$data)
     {
         if (is_array($data)) {
             $shouldBeObject = false;

--- a/src/Description/Document/Parser/YamlParser.php
+++ b/src/Description/Document/Parser/YamlParser.php
@@ -58,7 +58,7 @@ class YamlParser implements Parser
      *
      * @return mixed
      */
-    private function fixHashMaps(&$data)
+    private function fixHashMaps($data)
     {
         if (is_array($data)) {
             $shouldBeObject = false;


### PR DESCRIPTION
Hi, passing in the Yaml flags as booleans in deprecated since Symfony 3.1. This PR should fix the notices related to that.