### PR TITLE
Upgrade to phpunit 6.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
     "symfony/yaml": ">=2.8.7"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5.2",
-    "phpunit/phpunit-mock-objects": "^3.1",
+    "phpunit/phpunit": "^6.4",
     "mikey179/vfsStream": "^1.6",
     "doctrine/cache": "^1.6",
     "satooshi/php-coveralls": "^1.0"

--- a/tests/Description/Builder/OpenApi/ArrayReferenceTest.php
+++ b/tests/Description/Builder/OpenApi/ArrayReferenceTest.php
@@ -21,12 +21,9 @@ class ArrayReferenceTest extends OpenApiBuilderTest
         $this->setUpDescription('tests/definitions/openapi/data.yml');
     }
 
-    /**
-     * @test
-     */
-    public function arrayReferenceSchemaIsArraySchema()
+    public function testArrayReferenceSchemaIsArraySchema()
     {
-        $this->assertInstanceOf(
+        self::assertInstanceOf(
             ArraySchema::class,
             $this->description
                 ->getPath('/entity/{type}/findByCriteria')

--- a/tests/Description/Builder/OpenApi/ExtensionsApiBuilderTest.php
+++ b/tests/Description/Builder/OpenApi/ExtensionsApiBuilderTest.php
@@ -20,36 +20,24 @@ class ExtensionsApiBuilderTest extends OpenApiBuilderTest
         $this->setUpDescription('tests/definitions/openapi/extensions.yml');
     }
 
-    /**
-     * @test
-     */
-    public function getGetRootExtension()
+    public function testGetGetRootExtension()
     {
-        $this->assertSame('foo.bar', $this->description->getExtension('root'));
+        self::assertSame('foo.bar', $this->description->getExtension('root'));
     }
 
-    /**
-     * @test
-     */
-    public function getGetPathsExtension()
+    public function testGetGetPathsExtension()
     {
-        $this->assertSame('bar.foo', $this->description->getExtension('router'));
+        self::assertSame('bar.foo', $this->description->getExtension('router'));
     }
 
-    /**
-     * @test
-     */
-    public function getGetPathItemExtension()
+    public function testGetGetPathItemExtension()
     {
-        $this->assertSame('doh.foo', $this->description->getPath('/entity/{type}')->getExtension('router-controller'));
+        self::assertSame('doh.foo', $this->description->getPath('/entity/{type}')->getExtension('router-controller'));
     }
 
-    /**
-     * @test
-     */
-    public function canGetOperationExtension()
+    public function testCanGetOperationExtension()
     {
-        $this->assertSame(
+        self::assertSame(
             'bar.doh',
             $this->description->getPath('/entity/{type}')->getOperation('get')->getExtension('router-controller')
         );

--- a/tests/Description/Builder/OpenApi/PathParamApiBuilderTest.php
+++ b/tests/Description/Builder/OpenApi/PathParamApiBuilderTest.php
@@ -21,12 +21,9 @@ class PathParamApiBuilderTest extends OpenApiBuilderTest
         $this->setUpDescription('tests/definitions/openapi/data.yml');
     }
 
-    /**
-     * @test
-     */
-    public function canGetPathParameters()
+    public function testCanGetPathParameters()
     {
-        $this->assertCount(
+        self::assertCount(
             1,
             $this->description
                 ->getPath('/entity/{type}')
@@ -34,12 +31,9 @@ class PathParamApiBuilderTest extends OpenApiBuilderTest
         );
     }
 
-    /**
-     * @test
-     */
-    public function canGetPathParametersFromOperationObject()
+    public function testCanGetPathParametersFromOperationObject()
     {
-        $this->assertInstanceOf(
+        self::assertInstanceOf(
             Parameter::class,
             $this->description
                 ->getPath('/entity/{type}')

--- a/tests/Description/Builder/OpenApi/PetStoreBuilderTest.php
+++ b/tests/Description/Builder/OpenApi/PetStoreBuilderTest.php
@@ -24,16 +24,12 @@ class PetStoreBuilderTest extends OpenApiBuilderTest
         $this->setUpDescription('tests/definitions/openapi/petstore.yml');
     }
 
-
-    /**
-     * @test
-     */
-    public function hasComplexTypes()
+    public function testHasComplexTypes()
     {
         /** @var ComplexType[] $types */
         $types = [];
         foreach ($this->description->getComplexTypes() as $type) {
-            $this->assertInstanceOf(ComplexType::class, $type);
+            self::assertInstanceOf(ComplexType::class, $type);
             $types[$type->getName()] = $type;
         }
         $expected = [
@@ -43,29 +39,23 @@ class PetStoreBuilderTest extends OpenApiBuilderTest
             'Order',
             'User',
         ];
-        $this->assertSame($expected, array_keys($types));
+        self::assertSame($expected, array_keys($types));
         /** @var ObjectSchema $propertySchema */
         $propertySchema = $types['Pet']->getSchema()->getPropertySchema('category');
-        $this->assertSame($propertySchema->getComplexType(), $types['Category']);
-        $this->assertTrue($types['Pet']->getSchema()->getPropertySchema('category')->isType($types['Category']));
+        self::assertSame($propertySchema->getComplexType(), $types['Category']);
+        self::assertTrue($types['Pet']->getSchema()->getPropertySchema('category')->isType($types['Category']));
     }
 
-    /**
-     * @test
-     */
-    public function unknownPathThrowsException()
+    public function testUnknownPathThrowsException()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        self::expectException(\InvalidArgumentException::class);
 
         $this->description->getPath('foo');
     }
 
-    /**
-     * @test
-     */
-    public function canGetCollectionFormatFromParameter()
+    public function testCanGetCollectionFormatFromParameter()
     {
-        $this->assertSame(
+        self::assertSame(
             'multi',
             $this->description
                 ->getPath('/pets/findByStatus')
@@ -75,41 +65,29 @@ class PetStoreBuilderTest extends OpenApiBuilderTest
         );
     }
 
-    /**
-     * @test
-     */
-    public function unknownMethodThrowsException()
+    public function testUnknownMethodThrowsException()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        self::expectException(\InvalidArgumentException::class);
 
         $this->description->getPath('/pets')->getOperation('get');
     }
 
-    /**
-     * @test
-     */
-    public function unknownStatusCodeThrowsException()
+    public function testUnknownStatusCodeThrowsException()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        self::expectException(\InvalidArgumentException::class);
 
         $this->description->getPath('/pets')->getOperation('post')->getResponse(123);
     }
 
-    /**
-     * @test
-     */
-    public function canGetDefaultResponse()
+    public function testCanGetDefaultResponse()
     {
-        $this->assertInstanceOf(
+        self::assertInstanceOf(
             Response::class,
             $this->description->getPath('/users')->getOperation('post')->getResponse(123)
         );
     }
 
-    /**
-     * @test
-     */
-    public function canGetSupportedStatusCodes()
+    public function testCanGetSupportedStatusCodes()
     {
         $map = [
             '/pets'                     => ['post' => [405, 200], 'put' => [405, 404, 400, 200]],
@@ -134,7 +112,7 @@ class PetStoreBuilderTest extends OpenApiBuilderTest
 
         foreach ($this->description->getPaths() as $path) {
             foreach ($path->getOperations() as $operation) {
-                $this->assertSame(
+                self::assertSame(
                     $map[$operation->getPath()][$operation->getMethod()],
                     $operation->getStatusCodes(),
                     "Mismatch for operation {$operation->getId()}"
@@ -143,25 +121,16 @@ class PetStoreBuilderTest extends OpenApiBuilderTest
         }
     }
 
-    /**
-     * @test
-     */
-    public function canGetRequestBodyParameter()
+    public function testCanGetRequestBodyParameter()
     {
-        $this->assertInstanceOf(Parameter::class, $this->description->getRequestBodyParameter('/pets', 'post'));
+        self::assertInstanceOf(Parameter::class, $this->description->getRequestBodyParameter('/pets', 'post'));
     }
 
-    /**
-     * @test
-     */
-    public function getRequestBodyParameterWillReturnNullIfNonExistent()
+    public function testGetRequestBodyParameterWillReturnNullIfNonExistent()
     {
-        $this->assertNull($this->description->getRequestBodyParameter('/pets/findByStatus', 'get'));
+        self::assertNull($this->description->getRequestBodyParameter('/pets/findByStatus', 'get'));
     }
 
-    /**
-     * @test
-     */
     public function testGetters()
     {
         $map = [
@@ -171,7 +140,7 @@ class PetStoreBuilderTest extends OpenApiBuilderTest
 
         ];
         foreach ($map as $methodName => $value) {
-            $this->assertSame($value, $this->description->$methodName());
+            self::assertSame($value, $this->description->$methodName());
         }
     }
 }

--- a/tests/Description/Builder/OpenApi/SecurityTest.php
+++ b/tests/Description/Builder/OpenApi/SecurityTest.php
@@ -21,12 +21,9 @@ class SecurityTest extends OpenApiBuilderTest
         $this->setUpDescription('tests/definitions/openapi/mixed-security.yml');
     }
 
-    /**
-     * @test
-     */
-    public function noSecurityMarksOperationUnsecured()
+    public function testNoSecurityMarksOperationUnsecured()
     {
-        $this->assertFalse(
+        self::assertFalse(
             $this->description
                 ->getPath('/none')
                 ->getOperation('get')
@@ -34,12 +31,9 @@ class SecurityTest extends OpenApiBuilderTest
         );
     }
 
-    /**
-     * @test
-     */
-    public function apiKeySecurityMarksOperationSecured()
+    public function testApiKeySecurityMarksOperationSecured()
     {
-        $this->assertTrue(
+        self::assertTrue(
             $this->description
                 ->getPath('/apiKey')
                 ->getOperation('get')
@@ -47,12 +41,9 @@ class SecurityTest extends OpenApiBuilderTest
         );
     }
 
-    /**
-     * @test
-     */
-    public function oauth2SecurityMarksOperationSecured()
+    public function testOauth2SecurityMarksOperationSecured()
     {
-        $this->assertTrue(
+        self::assertTrue(
             $this->description
                 ->getPath('/oauth2')
                 ->getOperation('get')

--- a/tests/Description/Builder/OpenApiBuilderTest.php
+++ b/tests/Description/Builder/OpenApiBuilderTest.php
@@ -14,11 +14,12 @@ use KleijnWeb\PhpApi\Descriptions\Description\Document\Definition\Loader\Definit
 use KleijnWeb\PhpApi\Descriptions\Description\Document\Definition\RefResolver\RefResolver;
 use KleijnWeb\PhpApi\Descriptions\Description\Document\Document;
 use KleijnWeb\PhpApi\Descriptions\Description\Schema\Schema;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author John Kleijn <john@kleijnweb.nl>
  */
-abstract class OpenApiBuilderTest extends \PHPUnit_Framework_TestCase
+abstract class OpenApiBuilderTest extends TestCase
 {
     /**
      * @var Description
@@ -45,35 +46,26 @@ abstract class OpenApiBuilderTest extends \PHPUnit_Framework_TestCase
         $this->description = $builder->build();
     }
 
-    /**
-     * @test
-     */
-    public function isSerializable()
+    public function testIsSerializable()
     {
-        $this->assertEquals(unserialize(serialize($this->description)), $this->description);
+        self::assertEquals(unserialize(serialize($this->description)), $this->description);
     }
 
-    /**
-     * @test
-     */
-    public function canGetRequestSchema()
+    public function testCanGetRequestSchema()
     {
         foreach ($this->description->getPaths() as $path) {
             foreach ($path->getOperations() as $operation) {
                 $actual = $this->description->getRequestSchema($operation->getPath(), $operation->getMethod());
-                $this->assertInstanceOf(Schema::class, $actual);
+                self::assertInstanceOf(Schema::class, $actual);
                 $definition = $actual->getDefinition();
                 foreach ($operation->getParameters() as $parameter) {
-                    $this->assertObjectHasAttribute($parameter->getName(), $definition->properties);
+                    self::assertObjectHasAttribute($parameter->getName(), $definition->properties);
                 }
             }
         }
     }
 
-    /**
-     * @test
-     */
-    public function canGetResponseSchema()
+    public function testCanGetResponseSchema()
     {
         foreach ($this->description->getPaths() as $path) {
             foreach ($path->getOperations() as $operation) {
@@ -83,7 +75,7 @@ abstract class OpenApiBuilderTest extends \PHPUnit_Framework_TestCase
                         $operation->getMethod(),
                         $response->getCode()
                     );
-                    $this->assertInstanceOf(Schema::class, $actual);
+                    self::assertInstanceOf(Schema::class, $actual);
                 }
             }
         }

--- a/tests/Description/Builder/RamlBuilderTest.php
+++ b/tests/Description/Builder/RamlBuilderTest.php
@@ -22,11 +22,12 @@ use KleijnWeb\PhpApi\Descriptions\Description\Schema\ObjectSchema;
 use KleijnWeb\PhpApi\Descriptions\Description\Schema\ScalarSchema;
 use KleijnWeb\PhpApi\Descriptions\Description\Visitor\ClosureVisitor;
 use KleijnWeb\PhpApi\Descriptions\Description\Visitor\ClosureVisitorScope;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author John Kleijn <john@kleijnweb.nl>
  */
-class RamlBuilderTest extends \PHPUnit_Framework_TestCase
+class RamlBuilderTest extends TestCase
 {
     /**
      * @var Description
@@ -52,10 +53,7 @@ class RamlBuilderTest extends \PHPUnit_Framework_TestCase
         $this->description = $builder->build();
     }
 
-    /**
-     * @test
-     */
-    public function canVisitElements()
+    public function testCanVisitElements()
     {
         $scope = new class() implements ClosureVisitorScope
         {
@@ -83,60 +81,42 @@ class RamlBuilderTest extends \PHPUnit_Framework_TestCase
 
         sort($expected);
 
-        $this->assertSame($expected, $scope->types);
+        self::assertSame($expected, $scope->types);
     }
 
-    /**
-     * @test
-     */
-    public function willCreatePathObjectsUsingNestedResources()
+    public function testWillCreatePathObjectsUsingNestedResources()
     {
         $this->description->getPath('/orders/nested');
     }
 
-    /**
-     * @test
-     */
-    public function unknownPathThrowsException()
+    public function testUnknownPathThrowsException()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        self::expectException(\InvalidArgumentException::class);
 
         $this->description->getPath('foo');
     }
 
-    /**
-     * @test
-     */
-    public function unknownMethodThrowsException()
+    public function testUnknownMethodThrowsException()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        self::expectException(\InvalidArgumentException::class);
 
         $this->description->getPath('/orders')->getOperation('post');
     }
 
-    /**
-     * @test
-     */
-    public function unknownStatusCodeThrowsException()
+    public function testUnknownStatusCodeThrowsException()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        self::expectException(\InvalidArgumentException::class);
 
         $this->description->getPath('/orders')->getOperation('get')->getResponse(123);
     }
 
-    /**
-     * @test
-     */
-    public function canGetParametersFromOperation()
+    public function testCanGetParametersFromOperation()
     {
         $parameters = $this->description->getPath('/orders')->getOperation('get')->getParameters();
-        $this->assertCount(1, $parameters);
+        self::assertCount(1, $parameters);
     }
 
-    /**
-     * @test
-     */
-    public function canGetSupportedStatusCodes()
+    public function testCanGetSupportedStatusCodes()
     {
         $map = [
             '/orders' => ['get' => [200]],
@@ -144,7 +124,7 @@ class RamlBuilderTest extends \PHPUnit_Framework_TestCase
 
         foreach ($this->description->getPaths() as $path) {
             foreach ($path->getOperations() as $operation) {
-                $this->assertSame(
+                self::assertSame(
                     $map[$operation->getPath()][$operation->getMethod()],
                     $operation->getStatusCodes(),
                     "Mismatch for operation {$operation->getId()}"
@@ -153,9 +133,6 @@ class RamlBuilderTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    /**
-     * @test
-     */
     public function testGetters()
     {
         $map = [
@@ -165,7 +142,7 @@ class RamlBuilderTest extends \PHPUnit_Framework_TestCase
 
         ];
         foreach ($map as $methodName => $value) {
-            $this->assertSame($value, $this->description->$methodName());
+            self::assertSame($value, $this->description->$methodName());
         }
     }
 }

--- a/tests/Description/Builder/RamlBuilderTest.php
+++ b/tests/Description/Builder/RamlBuilderTest.php
@@ -86,7 +86,11 @@ class RamlBuilderTest extends TestCase
 
     public function testWillCreatePathObjectsUsingNestedResources()
     {
-        $this->description->getPath('/orders/nested');
+        $path = '/orders/nested';
+        $pathObject = $this->description->getPath($path);
+
+        self::assertInstanceOf(Path::class, $pathObject);
+        self::assertEquals($path, $pathObject->getPath());
     }
 
     public function testUnknownPathThrowsException()

--- a/tests/Description/DescriptionFactoryTest.php
+++ b/tests/Description/DescriptionFactoryTest.php
@@ -10,37 +10,29 @@ namespace KleijnWeb\PhpApi\Descriptions\Tests\Description;
 
 use KleijnWeb\PhpApi\Descriptions\Description\Description;
 use KleijnWeb\PhpApi\Descriptions\Description\DescriptionFactory;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author John Kleijn <john@kleijnweb.nl>
  */
-class DescriptionFactoryTest extends \PHPUnit_Framework_TestCase
+class DescriptionFactoryTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function canMakeDescriptionUsingRaml()
+    public function testCanMakeDescriptionUsingRaml()
     {
         $factory = new DescriptionFactory(DescriptionFactory::BUILDER_RAML);
-        $this->assertInstanceOf(Description::class, $factory->create('/foo', (object)[]));
+        self::assertInstanceOf(Description::class, $factory->create('/foo', (object)[]));
     }
 
-    /**
-     * @test
-     */
-    public function canMakeDescriptionUsingOpenApi()
+    public function testCanMakeDescriptionUsingOpenApi()
     {
         $factory = new DescriptionFactory(DescriptionFactory::BUILDER_RAML);
-        $this->assertInstanceOf(Description::class, $factory->create('/foo', (object)[]));
+        self::assertInstanceOf(Description::class, $factory->create('/foo', (object)[]));
     }
 
-    /**
-     * @test
-     */
-    public function willFailOtherwise()
+    public function testWillFailOtherwise()
     {
         $factory = new DescriptionFactory('x');
-        $this->setExpectedException(\InvalidArgumentException::class);
+        self::expectException(\InvalidArgumentException::class);
         $factory->create('/foo', (object)[]);
     }
 }

--- a/tests/Description/Document/Definition/Loader/DefinitionLoaderTest.php
+++ b/tests/Description/Document/Definition/Loader/DefinitionLoaderTest.php
@@ -13,43 +13,38 @@ use KleijnWeb\PhpApi\Descriptions\Description\Document\Definition\Loader\Resourc
 use KleijnWeb\PhpApi\Descriptions\Description\Document\Parser\Parser;
 use KleijnWeb\PhpApi\Descriptions\Description\Document\Reader\Reader;
 use KleijnWeb\PhpApi\Descriptions\Description\Document\Reader\Response;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author John Kleijn <john@kleijnweb.nl>
  */
-class DefinitionLoaderTest extends \PHPUnit_Framework_TestCase
+class DefinitionLoaderTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function willFailWithoutApplicableParser()
+    public function testWillFailWithoutApplicableParser()
     {
         $loader = new DefinitionLoader(
             $this->getMockForAbstractClass(Reader::class),
             $this->getMockForAbstractClass(Parser::class)
         );
-        $this->setExpectedException(ResourceNotParsableException::class);
+        self::expectException(ResourceNotParsableException::class);
         $loader->load('resource');
     }
 
-    /**
-     * @test
-     */
-    public function willReturnParsedDefinition()
+    public function testWillReturnParsedDefinition()
     {
         $uri         = 'resource';
         $definition  = (object)[];
         $reader      = $this->getMockForAbstractClass(Reader::class);
         $contentType = 'x-foo';
         $content     = (string)rand();
-        $reader->expects($this->once())->method('read')->with($uri)->willReturn(new Response($contentType, $content));
+        $reader->expects(self::once())->method('read')->with($uri)->willReturn(new Response($contentType, $content));
 
         $parser = $this->getMockForAbstractClass(Parser::class);
-        $parser->expects($this->once())->method('canParse')->with($contentType)->willReturn(true);
-        $parser->expects($this->once())->method('parse')->with($content)->willReturn($definition);
+        $parser->expects(self::once())->method('canParse')->with($contentType)->willReturn(true);
+        $parser->expects(self::once())->method('parse')->with($content)->willReturn($definition);
 
         $loader = new DefinitionLoader($reader, $parser);
 
-        $this->assertSame($definition, $loader->load($uri));
+        self::assertSame($definition, $loader->load($uri));
     }
 }

--- a/tests/Description/Document/Definition/RefResolver/RefResolverTest.php
+++ b/tests/Description/Document/Definition/RefResolver/RefResolverTest.php
@@ -12,16 +12,14 @@ use KleijnWeb\PhpApi\Descriptions\Description\Document\Definition\Loader\Definit
 use KleijnWeb\PhpApi\Descriptions\Description\Document\Definition\RefResolver\InvalidReferenceException;
 use KleijnWeb\PhpApi\Descriptions\Description\Document\Definition\RefResolver\RefResolver;
 use KleijnWeb\PhpApi\Descriptions\Description\Document\Parser\YamlParser;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author John Kleijn <john@kleijnweb.nl>
  */
-class RefResolverTest extends \PHPUnit_Framework_TestCase
+class RefResolverTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function willThrowInvalidReferenceException()
+    public function testWillThrowInvalidReferenceException()
     {
         $object   = (object)[
             'type'       => 'object',
@@ -33,14 +31,11 @@ class RefResolverTest extends \PHPUnit_Framework_TestCase
         ];
         $resolver = new RefResolver($object, '/foo');
 
-        $this->setExpectedException(InvalidReferenceException::class);
+        self::expectException(InvalidReferenceException::class);
         $resolver->resolve();
     }
 
-    /**
-     * @test
-     */
-    public function canResolveResourceSchemaReferences()
+    public function testCanResolveResourceSchemaReferences()
     {
         $resolver = $this->factory('petstore.yml');
         $resolver->resolve();
@@ -48,62 +43,49 @@ class RefResolverTest extends \PHPUnit_Framework_TestCase
         $schemas        = $resolver->getDefinition()->definitions;
         $propertySchema = $schemas->Pet->properties->category;
 
-        $this->assertObjectNotHasAttribute('$ref', $propertySchema);
-        $this->assertObjectHasAttribute('x-ref-id', $propertySchema);
-        $this->assertSame('object', $propertySchema->type);
+        self::assertObjectNotHasAttribute('$ref', $propertySchema);
+        self::assertObjectHasAttribute('x-ref-id', $propertySchema);
+        self::assertSame('object', $propertySchema->type);
     }
 
-    /**
-     * @test
-     */
-    public function canResolveParameterSchemaReferences()
+    public function testCanResolveParameterSchemaReferences()
     {
         $resolver        = $this->factory('instagram.yml');
         $pathDefinitions = $resolver->getDefinition()->paths;
         $pathDefinition  = $pathDefinitions->{'/users/{user-id}'};
 
-        $this->assertInternalType('array', $pathDefinition->parameters);
+        self::assertInternalType('array', $pathDefinition->parameters);
         $pathDefinition = $pathDefinitions->{'/users/{user-id}'};
 
         $resolver->resolve();
 
-        $this->assertInternalType('array', $pathDefinition->parameters);
+        self::assertInternalType('array', $pathDefinition->parameters);
         $argumentPseudoSchema = $pathDefinition->parameters[0];
 
-        $this->assertObjectNotHasAttribute('$ref', $argumentPseudoSchema);
-        $this->assertObjectHasAttribute('in', $argumentPseudoSchema);
-        $this->assertSame('user-id', $argumentPseudoSchema->name);
+        self::assertObjectNotHasAttribute('$ref', $argumentPseudoSchema);
+        self::assertObjectHasAttribute('in', $argumentPseudoSchema);
+        self::assertSame('user-id', $argumentPseudoSchema->name);
     }
 
-    /**
-     * @test
-     */
-    public function canResolveReferencesWithSlashed()
+    public function testCanResolveReferencesWithSlashed()
     {
         $resolver = $this->factory('partials/slashes.yml');
-        $this->assertSame('thevalue', $resolver->resolve()->Foo->bar);
+        self::assertSame('thevalue', $resolver->resolve()->Foo->bar);
     }
 
-    /**
-     * @test
-     *
-     */
-    public function canResolveExternalReferencesInExample()
+    public function testCanResolveExternalReferencesInExample()
     {
         $resolver = $this->factory('composite.yml');
         $document = $resolver->resolve();
 
-        $this->assertObjectHasAttribute('schema', $document->responses->Created);
+        self::assertObjectHasAttribute('schema', $document->responses->Created);
 
         $response = $document->paths->{'/pet'}->post->responses->{'500'};
 
-        $this->assertObjectHasAttribute('description', $response);
+        self::assertObjectHasAttribute('description', $response);
     }
 
-    /**
-     * @test
-     */
-    public function canUnResolve()
+    public function testCanUnResolve()
     {
         $resolver = $this->factory('composite.yml');
 
@@ -111,21 +93,19 @@ class RefResolverTest extends \PHPUnit_Framework_TestCase
         $resolver->resolve();
         $document = $resolver->unresolve();
 
-        $this->assertObjectNotHasAttribute('schema', $document->responses->Created);
-        $this->assertEquals($expected, $document);
+        self::assertObjectNotHasAttribute('schema', $document->responses->Created);
+        self::assertEquals($expected, $document);
     }
 
     /**
      * @dataProvider externalReferenceProvider
-     * @test
      *
      * @param mixed     $expected
      * @param string    $fileUrl
      * @param string    $uri
      * @param \stdClass $content
-     *
      */
-    public function willProperlyResolveExternalReferences($expected, string $fileUrl, string $uri, \stdClass $content)
+    public function testWillProperlyResolveExternalReferences($expected, string $fileUrl, string $uri, \stdClass $content)
     {
         $mockLoader = $this
             ->getMockBuilder(DefinitionLoader::class)
@@ -143,7 +123,7 @@ class RefResolverTest extends \PHPUnit_Framework_TestCase
 
         $value = $resolver->resolve();
 
-        $this->assertSame($expected, $value);
+        self::assertSame($expected, $value);
     }
 
     /**

--- a/tests/Description/Document/Definition/Validator/MetaSchemaValidatorTest.php
+++ b/tests/Description/Document/Definition/Validator/MetaSchemaValidatorTest.php
@@ -11,11 +11,12 @@ namespace KleijnWeb\PhpApi\Descriptions\Tests\Description\Document\Definition\Va
 use KleijnWeb\PhpApi\Descriptions\Description\Document\Definition\Validator\MetaSchemaValidator;
 use KleijnWeb\PhpApi\Descriptions\Description\Schema\Validator\SchemaValidator;
 use KleijnWeb\PhpApi\Descriptions\Description\Schema\Validator\ValidationResult;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author John Kleijn <john@kleijnweb.nl>
  */
-class MetaSchemaValidatorTest extends \PHPUnit_Framework_TestCase
+class MetaSchemaValidatorTest extends TestCase
 {
     /**
      * @var ValidationResult
@@ -30,31 +31,25 @@ class MetaSchemaValidatorTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $validator = $this->getMockForAbstractClass(SchemaValidator::class);
-        $validator->expects($this->once())->method('validate')->willReturnCallback(function () {
+        $validator->expects(self::once())->method('validate')->willReturnCallback(function () {
             return $this->expectedValidationResult;
         });
         /** @var SchemaValidator $validator */
         $this->validator = new MetaSchemaValidator((object)[], $validator);
     }
 
-    /**
-     * @test
-     */
-    public function canValidate()
+    public function testCanValidate()
     {
         $this->expectedValidationResult = new ValidationResult(true, []);
 
         $this->validator->validate((object)[]);
     }
 
-    /**
-     * @test
-     */
-    public function canInvalidate()
+    public function testCanInvalidate()
     {
         $this->expectedValidationResult = new ValidationResult(false, []);
 
-        $this->setExpectedException(\InvalidArgumentException::class);
+        self::expectException(\InvalidArgumentException::class);
         $this->validator->validate((object)[]);
 
     }

--- a/tests/Description/Document/Definition/Validator/OpenApiDefinitionValidatorTest.php
+++ b/tests/Description/Document/Definition/Validator/OpenApiDefinitionValidatorTest.php
@@ -32,6 +32,9 @@ class OpenApiDefinitionValidatorTest extends TestCase
     public function testCanValidate()
     {
         $this->validator->validate(json_decode(file_get_contents('tests/definitions/openapi/petstore.json')));
+
+        $value = 'This assertion is never reached on exception';
+        self::assertEquals($value, $value);
     }
 
     public function testCanInvalidate()

--- a/tests/Description/Document/Definition/Validator/OpenApiDefinitionValidatorTest.php
+++ b/tests/Description/Document/Definition/Validator/OpenApiDefinitionValidatorTest.php
@@ -11,11 +11,12 @@ namespace KleijnWeb\PhpApi\Descriptions\Tests\Description\Document\Definition\Va
 use KleijnWeb\PhpApi\Descriptions\Description\Document\Definition\Validator\MetaSchemaValidator;
 use KleijnWeb\PhpApi\Descriptions\Description\Document\Definition\Validator\OpenApiDefinitionValidator;
 use KleijnWeb\PhpApi\Descriptions\Description\Schema\Validator\SchemaValidator;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author John Kleijn <john@kleijnweb.nl>
  */
-class OpenApiDefinitionValidatorTest extends \PHPUnit_Framework_TestCase
+class OpenApiDefinitionValidatorTest extends TestCase
 {
     /**
      * @var MetaSchemaValidator
@@ -28,20 +29,14 @@ class OpenApiDefinitionValidatorTest extends \PHPUnit_Framework_TestCase
         $this->validator = new OpenApiDefinitionValidator();
     }
 
-    /**
-     * @test
-     */
-    public function canValidate()
+    public function testCanValidate()
     {
         $this->validator->validate(json_decode(file_get_contents('tests/definitions/openapi/petstore.json')));
     }
 
-    /**
-     * @test
-     */
-    public function canInvalidate()
+    public function testCanInvalidate()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        self::expectException(\InvalidArgumentException::class);
         $this->validator->validate((object)[]);
     }
 }

--- a/tests/Description/Document/DocumentTest.php
+++ b/tests/Description/Document/DocumentTest.php
@@ -9,11 +9,12 @@ namespace KleijnWeb\PhpApi\Descriptions\Tests\Description\Document;
 
 use KleijnWeb\PhpApi\Descriptions\Description\Document\Definition\Loader\DefinitionLoader;
 use KleijnWeb\PhpApi\Descriptions\Description\Document\Document;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author John Kleijn <john@kleijnweb.nl>
  */
-class DocumentTest extends \PHPUnit_Framework_TestCase
+class DocumentTest extends TestCase
 {
     /**
      * @var Document
@@ -27,23 +28,17 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
         $this->document = new Document($uri, $loader->load($uri));
     }
 
-    /**
-     * @test
-     */
-    public function canApplyRecursiveCallback()
+    public function testCanApplyRecursiveCallback()
     {
         $keys = [];
         $this->document->apply(function ($value, $key) use (&$keys) {
             $keys[] = $key;
         });
 
-        $this->assertCount(601, $keys);
+        self::assertCount(601, $keys);
     }
 
-    /**
-     * @test
-     */
-    public function canModifyValuesUsingRecursiveCallback()
+    public function testCanModifyValuesUsingRecursiveCallback()
     {
         $this->document->apply(function (&$value) {
             if (is_scalar($value)) {
@@ -57,13 +52,10 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
             }
         });
 
-        $this->assertCount(1, array_unique($values));
+        self::assertCount(1, array_unique($values));
     }
 
-    /**
-     * @test
-     */
-    public function canStopRecursiveProcessingByReturningFalse()
+    public function testCanStopRecursiveProcessingByReturningFalse()
     {
         $this->document->apply(function ($value, $key) use (&$keys) {
 
@@ -75,6 +67,6 @@ class DocumentTest extends \PHPUnit_Framework_TestCase
 
             return true;
         });
-        $this->assertCount(15, $keys);
+        self::assertCount(15, $keys);
     }
 }

--- a/tests/Description/Document/Parser/JsonParserTest.php
+++ b/tests/Description/Document/Parser/JsonParserTest.php
@@ -35,7 +35,10 @@ class JsonParserTest extends TestCase
 
     public function testCanLoadValidJson()
     {
-        $this->parser->parse(json_encode(['valid' => true]));
+        $object = $this->parser->parse(json_encode(['valid' => true]));
+
+        self::assertObjectHasAttribute('valid', $object);
+        self::assertTrue($object->valid);
     }
 
     /**

--- a/tests/Description/Document/Parser/JsonParserTest.php
+++ b/tests/Description/Document/Parser/JsonParserTest.php
@@ -10,11 +10,12 @@ namespace KleijnWeb\PhpApi\Descriptions\Tests\Description\Document\Parser;
 
 use KleijnWeb\PhpApi\Descriptions\Description\Document\Parser\JsonParser;
 use KleijnWeb\PhpApi\Descriptions\Description\Document\Parser\ParseException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author John Kleijn <john@kleijnweb.nl>
  */
-class JsonParserTest extends \PHPUnit_Framework_TestCase
+class JsonParserTest extends TestCase
 {
     /**
      * @var JsonParser
@@ -26,43 +27,30 @@ class JsonParserTest extends \PHPUnit_Framework_TestCase
         $this->parser = new JsonParser();
     }
 
-    /**
-     * @test
-     */
-    public function willFailWhenJsonIsNotDecodable()
+    public function testWillFailWhenJsonIsNotDecodable()
     {
-        $this->setExpectedException(ParseException::class);
+        self::expectException(ParseException::class);
         $this->parser->parse('NOT VALID JSON');
     }
 
-    /**
-     * @test
-     */
-    public function canLoadValidJson()
+    public function testCanLoadValidJson()
     {
         $this->parser->parse(json_encode(['valid' => true]));
     }
 
     /**
-     * @test
      * @dataProvider yamlContentTypeProvider
      */
-    public function willAcceptYamlContentTypes(string $contentType)
+    public function testWillAcceptYamlContentTypes(string $contentType)
     {
-        $this->assertTrue($this->parser->canParse($contentType));
+        self::assertTrue($this->parser->canParse($contentType));
     }
 
-    /**
-     * @test
-     */
-    public function willNotAcceptOtherContentType()
+    public function testWillNotAcceptOtherContentType()
     {
-        $this->assertFalse($this->parser->canParse('text/html'));
+        self::assertFalse($this->parser->canParse('text/html'));
     }
 
-    /**
-     * @test
-     */
     public function yamlContentTypeProvider()
     {
         return [

--- a/tests/Description/Document/Parser/JsonParserTest.php
+++ b/tests/Description/Document/Parser/JsonParserTest.php
@@ -42,9 +42,9 @@ class JsonParserTest extends TestCase
     }
 
     /**
-     * @dataProvider yamlContentTypeProvider
+     * @dataProvider jsonContentTypeProvider
      */
-    public function testWillAcceptYamlContentTypes(string $contentType)
+    public function testWillAcceptJsonContentTypes(string $contentType)
     {
         self::assertTrue($this->parser->canParse($contentType));
     }
@@ -54,7 +54,7 @@ class JsonParserTest extends TestCase
         self::assertFalse($this->parser->canParse('text/html'));
     }
 
-    public function yamlContentTypeProvider()
+    public function jsonContentTypeProvider()
     {
         return [
             ['text/json'],

--- a/tests/Description/Document/Parser/YamlParserTest.php
+++ b/tests/Description/Document/Parser/YamlParserTest.php
@@ -10,11 +10,12 @@ namespace KleijnWeb\PhpApi\Descriptions\Tests\Description\Document\Parser;
 
 use KleijnWeb\PhpApi\Descriptions\Description\Document\Parser\ParseException;
 use KleijnWeb\PhpApi\Descriptions\Description\Document\Parser\YamlParser;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author John Kleijn <john@kleijnweb.nl>
  */
-class YamlParserTest extends \PHPUnit_Framework_TestCase
+class YamlParserTest extends TestCase
 {
     /**
      * @var YamlParser
@@ -26,10 +27,7 @@ class YamlParserTest extends \PHPUnit_Framework_TestCase
         $this->parser = new YamlParser();
     }
 
-    /**
-     * @test
-     */
-    public function willFailWhenYamlIsNotDecodable()
+    public function testWillFailWhenYamlIsNotDecodable()
     {
         $yaml = <<<YAML
 foo:
@@ -38,31 +36,26 @@ foo:
   bar: 1
 YAML;
 
-        $this->setExpectedException(ParseException::class);
+        self::expectException(ParseException::class);
 
         $this->parser->parse($yaml);
     }
 
-    /**
-     * @test
-     */
-    public function canLoadValidYaml()
+    public function testCanLoadValidYaml()
     {
         $yaml = <<<YAML
 foo:
   bar: 1
 YAML;
-        $this->assertSame(1, $this->parser->parse($yaml)->foo->bar);
+        self::assertSame(1, $this->parser->parse($yaml)->foo->bar);
     }
 
     /**
      * Check Symfony\Yaml bug
      *
      * @see https://github.com/symfony/symfony/issues/17709
-     *
-     * @test
      */
-    public function canParseNumericMap()
+    public function testCanParseNumericMap()
     {
         $yaml   = <<<YAML
 map:
@@ -71,22 +64,20 @@ map:
 YAML;
         $parser = new  YamlParser();
         $actual = $parser->parse($yaml);
-        $this->assertInternalType('object', $actual);
-        $this->assertInternalType('object', $actual->map);
-        $this->assertTrue(property_exists($actual->map, '1'));
-        $this->assertTrue(property_exists($actual->map, '2'));
-        $this->assertSame('one', $actual->map->{'1'});
-        $this->assertSame('two', $actual->map->{'2'});
+        self::assertInternalType('object', $actual);
+        self::assertInternalType('object', $actual->map);
+        self::assertTrue(property_exists($actual->map, '1'));
+        self::assertTrue(property_exists($actual->map, '2'));
+        self::assertSame('one', $actual->map->{'1'});
+        self::assertSame('two', $actual->map->{'2'});
     }
 
     /**
      * Check Symfony\Yaml bug
      *
      * @see https://github.com/symfony/symfony/pull/17711
-     *
-     * @test
      */
-    public function willParseArrayAsArrayAndObjectAsObject()
+    public function testWillParseArrayAsArrayAndObjectAsObject()
     {
         $yaml = <<<YAML
 array:
@@ -96,35 +87,27 @@ YAML;
 
         $parser = new  YamlParser();
         $actual = $parser->parse($yaml);
-        $this->assertInternalType('object', $actual);
-
-        $this->assertInternalType('array', $actual->array);
-        $this->assertInternalType('object', $actual->array[0]);
-        $this->assertInternalType('object', $actual->array[1]);
-        $this->assertSame('one', $actual->array[0]->key);
-        $this->assertSame('two', $actual->array[1]->key);
+        self::assertInternalType('object', $actual);
+        self::assertInternalType('array', $actual->array);
+        self::assertInternalType('object', $actual->array[0]);
+        self::assertInternalType('object', $actual->array[1]);
+        self::assertSame('one', $actual->array[0]->key);
+        self::assertSame('two', $actual->array[1]->key);
     }
 
     /**
-     * @test
      * @dataProvider yamlContentTypeProvider
      */
-    public function willAcceptYamlContentTypes(string $contentType)
+    public function testWillAcceptYamlContentTypes(string $contentType)
     {
-        $this->assertTrue($this->parser->canParse($contentType));
+        self::assertTrue($this->parser->canParse($contentType));
     }
 
-    /**
-     * @test
-     */
-    public function willNotAcceptOtherContentType()
+    public function testWillNotAcceptOtherContentType()
     {
-        $this->assertFalse($this->parser->canParse('text/html'));
+        self::assertFalse($this->parser->canParse('text/html'));
     }
 
-    /**
-     * @test
-     */
     public function yamlContentTypeProvider()
     {
         return [

--- a/tests/Description/Document/Reader/SimpleReaderTest.php
+++ b/tests/Description/Document/Reader/SimpleReaderTest.php
@@ -18,13 +18,10 @@ class SimpleReaderTest extends TestCase
 {
     public function testWillFailWhenFileDoesNotExist()
     {
-        try {
-            $loader = new SimpleReader();
-            $loader->read('does/not/exist.json');
-        } catch (ResourceNotReadableException $e) {
-            return;
-        }
-        self::fail("Expected ResourceNotReadableException");
+        self::expectException(ResourceNotReadableException::class);
+
+        $loader = new SimpleReader();
+        $loader->read('does/not/exist.json');
     }
 
     public function testWillReturnContentTypeYamlIfUriLooksLikeYaml()

--- a/tests/Description/Document/Reader/SimpleReaderTest.php
+++ b/tests/Description/Document/Reader/SimpleReaderTest.php
@@ -9,16 +9,14 @@ namespace KleijnWeb\PhpApi\Descriptions\Tests\Description\Document\Reader;
 
 use KleijnWeb\PhpApi\Descriptions\Description\Document\Reader\ResourceNotReadableException;
 use KleijnWeb\PhpApi\Descriptions\Description\Document\Reader\SimpleReader;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author John Kleijn <john@kleijnweb.nl>
  */
-class SimpleReaderTest extends \PHPUnit_Framework_TestCase
+class SimpleReaderTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function willFailWhenFileDoesNotExist()
+    public function testWillFailWhenFileDoesNotExist()
     {
         try {
             $loader = new SimpleReader();
@@ -26,36 +24,27 @@ class SimpleReaderTest extends \PHPUnit_Framework_TestCase
         } catch (ResourceNotReadableException $e) {
             return;
         }
-        $this->fail("Expected ResourceNotReadableException");
+        self::fail("Expected ResourceNotReadableException");
     }
 
-    /**
-     * @test
-     */
-    public function willReturnContentTypeYamlIfUriLooksLikeYaml()
+    public function testWillReturnContentTypeYamlIfUriLooksLikeYaml()
     {
         $loader   = new SimpleReader();
         $response = $loader->read('tests/definitions/openapi/petstore.yml');
-        $this->assertSame(SimpleReader::CONTENT_TYPE_YAML, $response->getContentType());
+        self::assertSame(SimpleReader::CONTENT_TYPE_YAML, $response->getContentType());
     }
 
-    /**
-     * @test
-     */
-    public function willReturnContentTypeYamlIfUriLooksLikeRaml()
+    public function testWillReturnContentTypeYamlIfUriLooksLikeRaml()
     {
         $loader   = new SimpleReader();
         $response = $loader->read('tests/definitions/raml/mobile-order-api/api.raml');
-        $this->assertSame(SimpleReader::CONTENT_TYPE_YAML, $response->getContentType());
+        self::assertSame(SimpleReader::CONTENT_TYPE_YAML, $response->getContentType());
     }
 
-    /**
-     * @test
-     */
-    public function willReturnContentTypeJsonForEverythingElse()
+    public function testWillReturnContentTypeJsonForEverythingElse()
     {
         $loader   = new SimpleReader();
         $response = $loader->read(__FILE__);
-        $this->assertSame(SimpleReader::CONTENT_TYPE_JSON, $response->getContentType());
+        self::assertSame(SimpleReader::CONTENT_TYPE_JSON, $response->getContentType());
     }
 }

--- a/tests/Description/OperationTest.php
+++ b/tests/Description/OperationTest.php
@@ -12,16 +12,14 @@ use KleijnWeb\PhpApi\Descriptions\Description\Operation;
 use KleijnWeb\PhpApi\Descriptions\Description\Parameter;
 use KleijnWeb\PhpApi\Descriptions\Description\Schema\ScalarSchema;
 use KleijnWeb\PhpApi\Descriptions\Description\Schema\Schema;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author John Kleijn <john@kleijnweb.nl>
  */
-class OperationTest extends \PHPUnit_Framework_TestCase
+class OperationTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function canGetParameter()
+    public function testCanGetParameter()
     {
         $schema = new ScalarSchema((object)['type' => Schema::TYPE_ANY]);
 
@@ -31,25 +29,19 @@ class OperationTest extends \PHPUnit_Framework_TestCase
 
         $operation = new Operation('', '/foo', 'get', $parameters, $schema, []);
 
-        $this->assertInstanceOf(Parameter::class, $operation->getParameter('bar'));
+        self::assertInstanceOf(Parameter::class, $operation->getParameter('bar'));
     }
 
-    /**
-     * @test
-     */
-    public function willThrowExceptionIfParameterDoesNotExist()
+    public function testWillThrowExceptionIfParameterDoesNotExist()
     {
         $operation = new Operation('', '/foo', 'get', [], new ScalarSchema((object)['type' => Schema::TYPE_ANY]), []);
 
-        $this->setExpectedException(\OutOfBoundsException::class);
+        self::expectException(\OutOfBoundsException::class);
 
-        $this->assertInstanceOf(Parameter::class, $operation->getParameter('bar'));
+        self::assertInstanceOf(Parameter::class, $operation->getParameter('bar'));
     }
 
-    /**
-     * @test
-     */
-    public function canGetRequestBodyParameter()
+    public function testCanGetRequestBodyParameter()
     {
         $schema = new ScalarSchema((object)['type' => Schema::TYPE_ANY]);
 
@@ -61,25 +53,19 @@ class OperationTest extends \PHPUnit_Framework_TestCase
 
         $operation = new Operation('', '/foo', 'post', $parameters, $schema, []);
 
-        $this->assertInstanceOf(Parameter::class, $bodyParameter = $operation->getRequestBodyParameter());
+        self::assertInstanceOf(Parameter::class, $bodyParameter = $operation->getRequestBodyParameter());
 
-        $this->assertSame('bar', $bodyParameter->getName());
+        self::assertSame('bar', $bodyParameter->getName());
     }
 
-    /**
-     * @test
-     */
-    public function canGetMethod()
+    public function testCanGetMethod()
     {
         $operation = new Operation('', '/foo', 'put', [], new ScalarSchema((object)['type' => Schema::TYPE_ANY]), []);
 
-        $this->assertSame('put', $operation->getMethod());
+        self::assertSame('put', $operation->getMethod());
     }
 
-    /**
-     * @test
-     */
-    public function gettingRequestBodyParameterWillReturnNullIfOperationHasNoBodyParameter()
+    public function testGettingRequestBodyParameterWillReturnNullIfOperationHasNoBodyParameter()
     {
         $schema = new ScalarSchema((object)['type' => Schema::TYPE_ANY]);
 
@@ -90,6 +76,6 @@ class OperationTest extends \PHPUnit_Framework_TestCase
 
         $operation = new Operation('', '/foo', 'post', $parameters, $schema, []);
 
-        $this->assertNull($operation->getRequestBodyParameter());
+        self::assertNull($operation->getRequestBodyParameter());
     }
 }

--- a/tests/Description/RepositoryTest.php
+++ b/tests/Description/RepositoryTest.php
@@ -12,11 +12,12 @@ use KleijnWeb\PhpApi\Descriptions\Description\Description;
 use KleijnWeb\PhpApi\Descriptions\Description\Document\Document;
 use KleijnWeb\PhpApi\Descriptions\Description\Document\Reader\ResourceNotReadableException;
 use KleijnWeb\PhpApi\Descriptions\Description\Repository;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author John Kleijn <john@kleijnweb.nl>
  */
-class RepositoryTest extends \PHPUnit_Framework_TestCase
+class RepositoryTest extends TestCase
 {
     /**
      * @var Repository
@@ -28,51 +29,37 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
         $this->repository = new Repository();
     }
 
-    /**
-     * @test
-     * @expectedException \InvalidArgumentException
-     */
-    public function willFailWhenKeyIsEmpty()
+    public function testWillFailWhenKeyIsEmpty()
     {
+        self::expectException(\InvalidArgumentException::class);
+
         $this->repository->get('');
     }
 
-    /**
-     * @test
-     */
-    public function willFailWhenPathDoesNotExist()
+    public function testWillFailWhenPathDoesNotExist()
     {
-        $this->setExpectedException(ResourceNotReadableException::class);
+        self::expectException(ResourceNotReadableException::class);
         $this->repository->get('/this/is/total/bogus');
     }
 
-    /**
-     * @test
-     */
-    public function gettingDocumentThatDoestExistWillConstructIt()
+    public function testGettingDocumentThatDoestExistWillConstructIt()
     {
         $document = $this->repository->get('tests/definitions/openapi/petstore.yml');
-        $this->assertInstanceOf(Description::class, $document);
+        self::assertInstanceOf(Description::class, $document);
     }
 
-    /**
-     * @test
-     */
-    public function willCache()
+    public function testWillCache()
     {
         $path       = 'tests/definitions/openapi/petstore.yml';
         $cache      = $this->getMockBuilder(ArrayCache::class)->disableOriginalConstructor()->getMock();
         $repository = new Repository(null, $cache);
 
-        $cache->expects($this->exactly(1))->method('fetch')->with($path);
-        $cache->expects($this->exactly(1))->method('save')->with($path, $this->isType('object'));
+        $cache->expects(self::exactly(1))->method('fetch')->with($path);
+        $cache->expects(self::exactly(1))->method('save')->with($path, self::isType('object'));
         $repository->get($path);
     }
 
-    /**
-     * @test
-     */
-    public function willFetchFromCache()
+    public function testWillFetchFromCache()
     {
         $path        = 'tests/definitions/openapi/petstore.yml';
         $cache       = $this->getMockBuilder(ArrayCache::class)->disableOriginalConstructor()->getMock();
@@ -81,18 +68,15 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
 
         $repository = new Repository(null, $cache);
 
-        $cache->expects($this->exactly(1))->method('fetch')->with($path)->willReturn($description);
-        $this->assertInstanceOf(Description::class, $repository->get($path));
+        $cache->expects(self::exactly(1))->method('fetch')->with($path)->willReturn($description);
+        self::assertInstanceOf(Description::class, $repository->get($path));
     }
 
-    /**
-     * @test
-     */
-    public function canUsePathPrefix()
+    public function testCanUsePathPrefix()
     {
         $this->repository = new Repository('tests/definitions/');
         $document         = $this->repository->get('openapi/petstore.yml');
 
-        $this->assertInstanceOf(Description::class, $document);
+        self::assertInstanceOf(Description::class, $document);
     }
 }

--- a/tests/Description/Schema/ObjectSchemaTest.php
+++ b/tests/Description/Schema/ObjectSchemaTest.php
@@ -9,20 +9,18 @@ namespace KleijnWeb\PhpApi\Descriptions\Tests\Description\Schema;
 
 use KleijnWeb\PhpApi\Descriptions\Description\ComplexType;
 use KleijnWeb\PhpApi\Descriptions\Description\Schema\ObjectSchema;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author John Kleijn <john@kleijnweb.nl>
  */
-class ObjectSchemaTest extends \PHPUnit_Framework_TestCase
+class ObjectSchemaTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function cannotChangeComplexType()
+    public function testCannotChangeComplexType()
     {
         $schema = new ObjectSchema((object)[]);
         $schema->setComplexType(new ComplexType('Foo', $schema));
-        $this->setExpectedException(\LogicException::class);
+        self::expectException(\LogicException::class);
         $schema->setComplexType(new ComplexType('Foo', $schema));
     }
 }

--- a/tests/Description/Schema/SchemaFactoryTest.php
+++ b/tests/Description/Schema/SchemaFactoryTest.php
@@ -12,11 +12,12 @@ use KleijnWeb\PhpApi\Descriptions\Description\Schema\ObjectSchema;
 use KleijnWeb\PhpApi\Descriptions\Description\Schema\ScalarSchema;
 use KleijnWeb\PhpApi\Descriptions\Description\Schema\Schema;
 use KleijnWeb\PhpApi\Descriptions\Description\Schema\SchemaFactory;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author John Kleijn <john@kleijnweb.nl>
  */
-class SchemaFactoryTest extends \PHPUnit_Framework_TestCase
+class SchemaFactoryTest extends TestCase
 {
     /**
      * @var SchemaFactory
@@ -29,36 +30,28 @@ class SchemaFactoryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @test
-     *
      * @param \stdClass $definition
      *
      * @dataProvider simpleDefinitionProvider
      */
-    public function getWillReturnSameObjectForEqualDefinition(\stdClass $definition = null)
+    public function testGetWillReturnSameObjectForEqualDefinition(\stdClass $definition = null)
     {
         $schema1 = self::$factory->create($definition);
         $schema2 = self::$factory->create($definition);
 
-        $this->assertSame($schema1, $schema2);
+        self::assertSame($schema1, $schema2);
     }
 
-    /**
-     * @test
-     */
-    public function canGetNestedArraySchema()
+    public function testCanGetNestedArraySchema()
     {
         /** @var ArraySchema $schema */
         $schema = self::$factory->create((object)['type' => 'array', 'items' => (object)['type' => 'number']]);
 
-        $this->assertInstanceOf(Schema::class, $schema->getItemsSchema());
-        $this->assertTrue($schema->getItemsSchema()->isType(Schema::TYPE_NUMBER));
+        self::assertInstanceOf(Schema::class, $schema->getItemsSchema());
+        self::assertTrue($schema->getItemsSchema()->isType(Schema::TYPE_NUMBER));
     }
 
-    /**
-     * @test
-     */
-    public function canGetNestedPropertySchemas()
+    public function testCanGetNestedPropertySchemas()
     {
         /** @var ObjectSchema $schema */
         $schema = self::$factory->create((object)[
@@ -66,14 +59,11 @@ class SchemaFactoryTest extends \PHPUnit_Framework_TestCase
             'properties' => ['foo' => (object)['type' => 'string']]
         ]);
 
-        $this->assertInstanceOf(\stdClass::class, $schema->getPropertySchemas());
-        $this->assertObjectHasAttribute('foo', $schema->getPropertySchemas());
+        self::assertInstanceOf(\stdClass::class, $schema->getPropertySchemas());
+        self::assertObjectHasAttribute('foo', $schema->getPropertySchemas());
     }
 
-    /**
-     * @test
-     */
-    public function canGetNestedPropertySchemaByPropertyName()
+    public function testCanGetNestedPropertySchemaByPropertyName()
     {
         /** @var ObjectSchema $schema */
         $schema = self::$factory->create(
@@ -86,14 +76,11 @@ class SchemaFactoryTest extends \PHPUnit_Framework_TestCase
             ]
         );
 
-        $this->assertInstanceOf(Schema::class, $schema->getPropertySchema('bar'));
-        $this->assertTrue($schema->getPropertySchema('bar')->isType(Schema::TYPE_NUMBER));
+        self::assertInstanceOf(Schema::class, $schema->getPropertySchema('bar'));
+        self::assertTrue($schema->getPropertySchema('bar')->isType(Schema::TYPE_NUMBER));
     }
 
-    /**
-     * @test
-     */
-    public function canTestIfHasPropertySchema()
+    public function testCanTestIfHasPropertySchema()
     {
         /** @var ObjectSchema $schema */
         $schema = self::$factory->create(
@@ -105,14 +92,11 @@ class SchemaFactoryTest extends \PHPUnit_Framework_TestCase
             ]
         );
 
-        $this->assertFalse($schema->hasPropertySchema('x'));
-        $this->assertTrue($schema->hasPropertySchema('bar'));
+        self::assertFalse($schema->hasPropertySchema('x'));
+        self::assertTrue($schema->hasPropertySchema('bar'));
     }
 
-    /**
-     * @test
-     */
-    public function canFailToGetNestedPropertySchemaByPropertyName()
+    public function testCanFailToGetNestedPropertySchemaByPropertyName()
     {
         /** @var ObjectSchema $schema */
         $schema = self::$factory->create(
@@ -124,14 +108,11 @@ class SchemaFactoryTest extends \PHPUnit_Framework_TestCase
             ]
         );
 
-        $this->setExpectedException(\OutOfBoundsException::class);
-        $this->assertInstanceOf(Schema::class, $schema->getPropertySchema('x'));
+        self::expectException(\OutOfBoundsException::class);
+        self::assertInstanceOf(Schema::class, $schema->getPropertySchema('x'));
     }
 
-    /**
-     * @test
-     */
-    public function schemaTypeWillDefaultToLastNestedType()
+    public function testSchemaTypeWillDefaultToLastNestedType()
     {
         /** @var ObjectSchema $schema */
         $schema = self::$factory->create(
@@ -143,13 +124,10 @@ class SchemaFactoryTest extends \PHPUnit_Framework_TestCase
             ]
         );
 
-        $this->assertSame('integer', $schema->getType());
+        self::assertSame('integer', $schema->getType());
     }
 
-    /**
-     * @test
-     */
-    public function willMergePropertiesWhenUsingAllOf()
+    public function testWillMergePropertiesWhenUsingAllOf()
     {
         /** @var ObjectSchema $schema */
         $schema = self::$factory->create(
@@ -171,8 +149,8 @@ class SchemaFactoryTest extends \PHPUnit_Framework_TestCase
             ]
         );
 
-        $this->assertInstanceOf(ScalarSchema::class, $schema->getPropertySchema('foo'));
-        $this->assertInstanceOf(ScalarSchema::class, $schema->getPropertySchema('bar'));
+        self::assertInstanceOf(ScalarSchema::class, $schema->getPropertySchema('foo'));
+        self::assertInstanceOf(ScalarSchema::class, $schema->getPropertySchema('bar'));
     }
 
     public function simpleDefinitionProvider()

--- a/tests/Description/Schema/Validator/JustinRainbowSchemaValidatorAdapterTest.php
+++ b/tests/Description/Schema/Validator/JustinRainbowSchemaValidatorAdapterTest.php
@@ -10,13 +10,11 @@ namespace KleijnWeb\PhpApi\Descriptions\Tests\Description\Schema\Validator;
 
 use KleijnWeb\PhpApi\Descriptions\Description\Schema;
 use KleijnWeb\PhpApi\Descriptions\Description\Schema\Validator\JustinRainbowSchemaValidatorAdapter;
+use PHPUnit\Framework\TestCase;
 
-class JustinRainbowSchemaValidatorAdapterTest extends \PHPUnit_Framework_TestCase
+class JustinRainbowSchemaValidatorAdapterTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function willContainIndexedErrors()
+    public function testWillContainIndexedErrors()
     {
         $factory = new Schema\SchemaFactory();
 
@@ -42,19 +40,16 @@ class JustinRainbowSchemaValidatorAdapterTest extends \PHPUnit_Framework_TestCas
             ]),
             (object)['foo' => (object)['bar' => 1]]
         );
-        $this->assertFalse($result->isValid());
+        self::assertFalse($result->isValid());
 
         $expected = [
             'bar'     => 'The property bar is required',
             'foo.bar' => 'Must have a minimum value of 10',
         ];
-        $this->assertSame($expected, $result->getErrorMessages());
+        self::assertSame($expected, $result->getErrorMessages());
     }
 
-    /**
-     * @test
-     */
-    public function canForceNoAdditionalProperties()
+    public function testCanForceNoAdditionalProperties()
     {
         $factory = new Schema\SchemaFactory();
 
@@ -69,17 +64,14 @@ class JustinRainbowSchemaValidatorAdapterTest extends \PHPUnit_Framework_TestCas
             (object)['bar' => 1],
             true
         );
-        $this->assertFalse($result->isValid());
+        self::assertFalse($result->isValid());
 
         $expected = ['' => 'The property bar is not defined and the definition does not allow additional properties'];
 
-        $this->assertSame($expected, $result->getErrorMessages());
+        self::assertSame($expected, $result->getErrorMessages());
     }
 
-    /**
-     * @test
-     */
-    public function canDefaultToRequireAll()
+    public function testCanDefaultToRequireAll()
     {
         $factory = new Schema\SchemaFactory();
 
@@ -96,10 +88,10 @@ class JustinRainbowSchemaValidatorAdapterTest extends \PHPUnit_Framework_TestCas
             false,
             true
         );
-        $this->assertFalse($result->isValid());
+        self::assertFalse($result->isValid());
 
         $expected = ['bar' => 'The property bar is required'];
 
-        $this->assertSame($expected, $result->getErrorMessages());
+        self::assertSame($expected, $result->getErrorMessages());
     }
 }

--- a/tests/MessageValidatorTest.php
+++ b/tests/MessageValidatorTest.php
@@ -11,20 +11,20 @@ use KleijnWeb\PhpApi\Descriptions\Description\DescriptionFactory;
 use KleijnWeb\PhpApi\Descriptions\Description\Repository;
 use KleijnWeb\PhpApi\Descriptions\MessageValidator;
 use KleijnWeb\PhpApi\Descriptions\Tests\Mixins\HttpMessageMockingMixin;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * @author John Kleijn <john@kleijnweb.nl>
  */
-class MessageValidatorTest extends \PHPUnit_Framework_TestCase
+class MessageValidatorTest extends TestCase
 {
     use HttpMessageMockingMixin;
 
     /**
-     * @test
      * @group integration
      */
-    public function canValidateUsingOpenApiDescription()
+    public function testCanValidateUsingOpenApiDescription()
     {
         $validator = new MessageValidator(
             (new Repository())
@@ -42,20 +42,19 @@ class MessageValidatorTest extends \PHPUnit_Framework_TestCase
         /** @var ServerRequestInterface $request */
         $result = $validator->validateRequest($request, $path);
 
-        $this->assertTrue($result->isValid());
+        self::assertTrue($result->isValid());
 
         $response = $this->mockResponse(200);
         $body     = (object)[];
         $result   = $validator->validateResponse($body, $request, $response, $path);
 
-        $this->assertTrue($result->isValid());
+        self::assertTrue($result->isValid());
     }
 
     /**
-     * @test
      * @group integration
      */
-    public function canValidateUsingRamlDescription()
+    public function testCanValidateUsingRamlDescription()
     {
         $validator = new MessageValidator(
             (new Repository())
@@ -71,12 +70,12 @@ class MessageValidatorTest extends \PHPUnit_Framework_TestCase
         /** @var ServerRequestInterface $request */
         $result = $validator->validateRequest($request, $path);
 
-        $this->assertTrue($result->isValid());
+        self::assertTrue($result->isValid());
 
         $response = $this->mockResponse(200);
         $body     = (object)[];
         $result   = $validator->validateResponse($body, $request, $response, $path);
 
-        $this->assertTrue($result->isValid());
+        self::assertTrue($result->isValid());
     }
 }

--- a/tests/Mixins/HttpMessageMockingMixin.php
+++ b/tests/Mixins/HttpMessageMockingMixin.php
@@ -37,20 +37,20 @@ trait HttpMessageMockingMixin
 
 
         $message = $this->getMockForAbstractClass(ServerRequestInterface::class);
-        $message->expects($this->once())->method('getQueryParams')->willReturn($query);
-        $message->expects($this->any())->method('getMethod')->willReturn($method);
+        $message->expects(self::once())->method('getQueryParams')->willReturn($query);
+        $message->expects(self::any())->method('getMethod')->willReturn($method);
 
-        $message->expects($this->once())->method('getUri')->willReturnCallback(function () use ($path) {
+        $message->expects(self::once())->method('getUri')->willReturnCallback(function () use ($path) {
             $uri = $this->getMockForAbstractClass(UriInterface::class);
-            $uri->expects($this->once())->method('getPath')->willReturn($path);
+            $uri->expects(self::once())->method('getPath')->willReturn($path);
 
             return $uri;
         });
 
-        $message->expects($this->once())->method('getHeaders')->willReturn($headers);
+        $message->expects(self::once())->method('getHeaders')->willReturn($headers);
 
         if (null !== $body) {
-            $message->expects($this->once())->method('getParsedBody')->willReturn($body);
+            $message->expects(self::once())->method('getParsedBody')->willReturn($body);
         }
 
         return $message;
@@ -64,7 +64,7 @@ trait HttpMessageMockingMixin
     protected function mockResponse(int $statusCode): ResponseInterface
     {
         $message = $this->getMockForAbstractClass(ResponseInterface::class);
-        $message->expects($this->once())->method('getStatusCode')->willReturn($statusCode);
+        $message->expects(self::once())->method('getStatusCode')->willReturn($statusCode);
 
         return $message;
     }
@@ -95,10 +95,10 @@ trait HttpMessageMockingMixin
     /**
      * @return \PHPUnit_Framework_MockObject_Matcher_Invocation
      */
-    abstract protected function once();
+    abstract protected static function once();
 
     /**
      * @return \PHPUnit_Framework_MockObject_Matcher_Invocation
      */
-    abstract protected function any();
+    abstract protected static function any();
 }

--- a/tests/Request/ParameterCoercerTest.php
+++ b/tests/Request/ParameterCoercerTest.php
@@ -13,11 +13,12 @@ use KleijnWeb\PhpApi\Descriptions\Description\Schema\ObjectSchema;
 use KleijnWeb\PhpApi\Descriptions\Description\Schema\ScalarSchema;
 use KleijnWeb\PhpApi\Descriptions\Description\Schema\Schema;
 use KleijnWeb\PhpApi\Descriptions\Request\ParameterCoercer;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author John Kleijn <john@kleijnweb.nl>
  */
-class ParameterCoercerTest extends \PHPUnit_Framework_TestCase
+class ParameterCoercerTest extends TestCase
 {
     /**
      * @var ParameterCoercer
@@ -29,26 +30,22 @@ class ParameterCoercerTest extends \PHPUnit_Framework_TestCase
         $this->coercer = new ParameterCoercer();
     }
 
-    /**
-     * @test
-     */
-    public function willReturnOriginalValueIfTypeDoesNotMatchKnownType()
+    public function testWillReturnOriginalValueIfTypeDoesNotMatchKnownType()
     {
         $value  = (object)[];
         $actual = $this->coercer->coerce($this->createParameter(['getType' => 'x']), $value);
-        $this->assertSame($value, $actual);
+        self::assertSame($value, $actual);
     }
 
     /**
      * @dataProvider conversionProvider
-     * @test
      *
      * @param string $type
      * @param mixed  $value
      * @param mixed  $expected
      * @param string $format
      */
-    public function willInterpretValuesAsExpected($type, $value, $expected, $format = null)
+    public function testWillInterpretValuesAsExpected($type, $value, $expected, $format = null)
     {
         $stubs       = [];
         $schemaStubs = ['getType' => $type];
@@ -63,34 +60,32 @@ class ParameterCoercerTest extends \PHPUnit_Framework_TestCase
         $actual = $this->coercer->coerce($this->createParameter($schemaStubs, $stubs), $value);
 
         if (is_object($expected)) {
-            $this->assertEquals($expected, $actual);
+            self::assertEquals($expected, $actual);
 
             return;
         }
-        $this->assertSame($expected, $actual);
+        self::assertSame($expected, $actual);
     }
 
     /**
      * @dataProvider malformedConversionProvider
-     * @test
      *
      * @param string $type
      * @param mixed  $value
      */
-    public function willNotChangeUninterpretableValues($type, $value)
+    public function testWillNotChangeUninterpretableValues($type, $value)
     {
         $actual = $this->coercer->coerce($this->createParameter(['getType' => $type]), $value);
-        $this->assertSame($value, $actual);
+        self::assertSame($value, $actual);
     }
 
     /**
      * @dataProvider malformedDateTimeConversionProvider
-     * @test
      *
      * @param string $format
      * @param mixed  $value
      */
-    public function willNotChangeUninterpretableDateTimeAsExpected($format, $value)
+    public function testWillNotChangeUninterpretableDateTimeAsExpected($format, $value)
     {
         $actual = $this->coercer->coerce(
             $this->createParameter([
@@ -99,15 +94,12 @@ class ParameterCoercerTest extends \PHPUnit_Framework_TestCase
             ]),
             $value
         );
-        $this->assertSame($value, $actual);
+        self::assertSame($value, $actual);
     }
 
-    /**
-     * @test
-     */
-    public function willThrowUnsupportedExceptionInPredefinedCases()
+    public function testWillThrowUnsupportedExceptionInPredefinedCases()
     {
-        $this->setExpectedException(\RuntimeException::class);
+        self::expectException(\RuntimeException::class);
         $this->coercer->coerce(
             $this->createParameter(
                 ['getType' => 'array'],
@@ -210,7 +202,7 @@ class ParameterCoercerTest extends \PHPUnit_Framework_TestCase
         $parameterMock = $this->getMockBuilder(Parameter::class)->disableOriginalConstructor()->getMock();
 
         foreach ($stubs as $methodName => $value) {
-            $parameterMock->expects($this->any())->method($methodName)->willReturn($value);
+            $parameterMock->expects(self::any())->method($methodName)->willReturn($value);
         }
 
         switch ($schemaStubs['getType']) {
@@ -224,10 +216,10 @@ class ParameterCoercerTest extends \PHPUnit_Framework_TestCase
                 $schemaMock = $this->getMockBuilder(ScalarSchema::class)->disableOriginalConstructor()->getMock();
         }
 
-        $parameterMock->expects($this->any())->method('getSchema')->willReturn($schemaMock);
+        $parameterMock->expects(self::any())->method('getSchema')->willReturn($schemaMock);
 
         foreach ($schemaStubs as $methodName => $value) {
-            $schemaMock->expects($this->any())->method($methodName)->willReturn($value);
+            $schemaMock->expects(self::any())->method($methodName)->willReturn($value);
         }
 
         return $parameterMock;

--- a/tests/Request/RequestParameterAssemblerTest.php
+++ b/tests/Request/RequestParameterAssemblerTest.php
@@ -12,12 +12,13 @@ use KleijnWeb\PhpApi\Descriptions\Description\Parameter;
 use KleijnWeb\PhpApi\Descriptions\Request\ParameterCoercer;
 use KleijnWeb\PhpApi\Descriptions\Request\RequestParameterAssembler;
 use KleijnWeb\PhpApi\Descriptions\Tests\Mixins\HttpMessageMockingMixin;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * @author John Kleijn <john@kleijnweb.nl>
  */
-class RequestParameterAssemblerTest extends \PHPUnit_Framework_TestCase
+class RequestParameterAssemblerTest extends TestCase
 {
     use HttpMessageMockingMixin;
 
@@ -29,17 +30,14 @@ class RequestParameterAssemblerTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $coercer = $this->getMockBuilder(ParameterCoercer::class)->disableOriginalConstructor()->getMock();
-        $coercer->expects($this->any())->method('coerce')->willReturnCallback(function ($parameter, $value) {
+        $coercer->expects(self::any())->method('coerce')->willReturnCallback(function ($parameter, $value) {
             return $value;
         });
 
         $this->assembler = new RequestParameterAssembler($coercer);
     }
 
-    /**
-     * @test
-     */
-    public function canAssembleQueryParameters()
+    public function testCanAssembleQueryParameters()
     {
         $params    = [
             'foo' => 'bar',
@@ -56,13 +54,10 @@ class RequestParameterAssemblerTest extends \PHPUnit_Framework_TestCase
         /** @var ServerRequestInterface $message */
         $actual = $this->assembler->getRequestParameters($message, $operation);
 
-        $this->assertEquals((object)$params, $actual);
+        self::assertEquals((object)$params, $actual);
     }
 
-    /**
-     * @test
-     */
-    public function canAssemblePathParameters()
+    public function testCanAssemblePathParameters()
     {
         $params    = [
             'foo' => 'bar',
@@ -80,13 +75,10 @@ class RequestParameterAssemblerTest extends \PHPUnit_Framework_TestCase
         /** @var ServerRequestInterface $message */
         $actual = $this->assembler->getRequestParameters($message, $operation);
 
-        $this->assertEquals((object)$params, $actual);
+        self::assertEquals((object)$params, $actual);
     }
 
-    /**
-     * @test
-     */
-    public function canAssembleHeaderParameters()
+    public function testCanAssembleHeaderParameters()
     {
         $params    = [
             'foo' => 'bar',
@@ -104,13 +96,10 @@ class RequestParameterAssemblerTest extends \PHPUnit_Framework_TestCase
         /** @var ServerRequestInterface $message */
         $actual = $this->assembler->getRequestParameters($message, $operation);
 
-        $this->assertEquals((object)$params, $actual);
+        self::assertEquals((object)$params, $actual);
     }
 
-    /**
-     * @test
-     */
-    public function willSkipHeaderWithoutValue()
+    public function testWillSkipHeaderWithoutValue()
     {
         $params    = [
             'baz' => '1'
@@ -127,13 +116,10 @@ class RequestParameterAssemblerTest extends \PHPUnit_Framework_TestCase
         /** @var ServerRequestInterface $message */
         $actual = $this->assembler->getRequestParameters($message, $operation);
 
-        $this->assertEquals((object)$params, $actual);
+        self::assertEquals((object)$params, $actual);
     }
 
-    /**
-     * @test
-     */
-    public function willCopyBodyAsIs()
+    public function testWillCopyBodyAsIs()
     {
         $body = (object)['baz' => '1'];
 
@@ -148,30 +134,30 @@ class RequestParameterAssemblerTest extends \PHPUnit_Framework_TestCase
         $params = $this->assembler->getRequestParameters($message, $operation);
         $actual = $params->foo;
 
-        $this->assertSame($body, $actual);
+        self::assertSame($body, $actual);
     }
 
     /**
+     * @param string $path
      * @param array $parameterStubs
-     *
      * @return Operation
      */
     private function createOperation(string $path, array $parameterStubs = []): Operation
     {
         $operationMock = $this->getMockBuilder(Operation::class)->disableOriginalConstructor()->getMock();
-        $operationMock->expects($this->once())->method('getPath')->willReturn($path);
+        $operationMock->expects(self::once())->method('getPath')->willReturn($path);
         $parameterMocks = [];
 
         foreach ($parameterStubs as $parameterName => $stubs) {
             $parameterMock = $this->getMockBuilder(Parameter::class)->disableOriginalConstructor()->getMock();
-            $parameterMock->expects($this->any())->method('getName')->willReturn($parameterName);
+            $parameterMock->expects(self::any())->method('getName')->willReturn($parameterName);
 
             foreach ($stubs as $methodName => $value) {
-                $parameterMock->expects($this->any())->method($methodName)->willReturn($value);
+                $parameterMock->expects(self::any())->method($methodName)->willReturn($value);
             }
             $parameterMocks[$parameterName] = $parameterMock;
         }
-        $operationMock->expects($this->any())->method('getParameters')->willReturn($parameterMocks);
+        $operationMock->expects(self::any())->method('getParameters')->willReturn($parameterMocks);
 
         return $operationMock;
     }


### PR DESCRIPTION
> PHPUnit 5.7 is the old stable release series.
> It became stable on December 2, 2016.
> Support for PHPUnit 5 ends on February 2, 2018.
> — https://phpunit.de/