### PR TITLE
Added missing range identifier for psr/http-message.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   ],
   "require": {
     "php": "^7.0.0",
-    "psr/http-message": "1.0",
+    "psr/http-message": "^1.0",
     "symfony/yaml": ">=2.8.7",
     "league/json-guard": "^1.0",
     "psr/simple-cache": "^1.0"


### PR DESCRIPTION
This was preventing the use of `1.0.1` and such. I currently couldn't `composer require kleijnweb/swagger-bundle:^4.0-beta2` because I already had `1.0.1` installed.